### PR TITLE
Add compatibility to different symfony versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,52 @@
 sudo: false
 language: php
-php:
-  - 7.2
-  - 7.3
-  - 7.4
+
+
+matrix:
+  include:
+    - language: php
+      php: 5.6
+      env:
+        - SYMFONY=^3.4
+
+    - language: php
+      php: 7.0
+      env:
+        - SYMFONY=^3.4
+
+    - language: php
+      php: 7.2
+      env:
+        - SYMFONY=^3.4
+
+    - language: php
+      php: 7.3
+      env:
+        - SYMFONY=^4.4
+
+    - language: php
+      php: 7.4
+      env:
+        - SYMFONY=^5.0
+
 env:
   global:
     - ES_VERSION=6.8.2 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
+
 install:
   - wget ${ES_DOWNLOAD_URL}
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
   - ./elasticsearch-${ES_VERSION}/bin/elasticsearch -d
+
 before_script:
   - if [ "$GITHUB_COMPOSER_AUTH" ]; then composer config -g github-oauth.github.com $GITHUB_COMPOSER_AUTH; fi
+  - composer require --no-update symfony/symfony:${SYMFONY}
   - composer install --no-interaction --prefer-dist
+
 script:
   - wget -q --waitretry=1 --retry-connrefused -T 10 -O - http://127.0.0.1:9200
   - vendor/bin/phpunit --coverage-clover=coverage.xml
   - vendor/bin/phpcs -p --standard=PSR2 --ignore=vendor/ ./
+
 after_script:
   - travis_retry bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,12 @@
 sudo: false
 language: php
 
-
 matrix:
   include:
     - language: php
-      php: 5.6
+      php: 7.1
       env:
-        - SYMFONY=^3.4
-
-    - language: php
-      php: 7.0
-      env:
-        - SYMFONY=^3.4
+        - SYMFONY=^2.8
 
     - language: php
       php: 7.2

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
         }
     ],
     "require": {
-        "php": "^7.2",
-        "symfony/serializer": "^3.4 || ^4.0 || ^5.0",
+        "php": "^5.6 || ^7.2",
+        "symfony/serializer": "^2.8 || ^3.4 || ^4.0 || ^5.0",
         "paragonie/random_compat": "*",
         "elasticsearch/elasticsearch": "^6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "symfony/serializer": "^5.0",
+        "symfony/serializer": "^3.4 || ^4.0 || ^5.0",
         "paragonie/random_compat": "*",
         "elasticsearch/elasticsearch": "^6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,14 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.2",
+        "php": "^7.1",
         "symfony/serializer": "^2.8 || ^3.4 || ^4.0 || ^5.0",
         "paragonie/random_compat": "*",
         "elasticsearch/elasticsearch": "^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
-        "squizlabs/php_codesniffer": "^3.0"
+        "phpunit/phpunit": "^5.7.26 || ^7.5.20",
+        "squizlabs/php_codesniffer": "^2.0 || ^3.0"
     },
     "suggest": {
       "elasticsearch/elasticsearch": "This library is for elasticsearch/elasticsearch client to enhance it with DSL functionality."

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
         convertWarningsToExceptions="true"
         processIsolation="false"
         stopOnFailure="false"
-        syntaxCheck="false"
         bootstrap="vendor/autoload.php">
 
     <testsuites>

--- a/src/SearchEndpoint/AggregationsEndpoint.php
+++ b/src/SearchEndpoint/AggregationsEndpoint.php
@@ -27,7 +27,7 @@ class AggregationsEndpoint extends AbstractSearchEndpoint
     /**
      * {@inheritdoc}
      */
-    public function normalize(NormalizerInterface $normalizer, string $format = null, array $context = [])
+    public function normalize(NormalizerInterface $normalizer, $format = null, array $context = [])
     {
         $output = [];
         if (count($this->getAll()) > 0) {

--- a/src/SearchEndpoint/HighlightEndpoint.php
+++ b/src/SearchEndpoint/HighlightEndpoint.php
@@ -37,7 +37,7 @@ class HighlightEndpoint extends AbstractSearchEndpoint
     /**
      * {@inheritdoc}
      */
-    public function normalize(NormalizerInterface $normalizer, string $format = null, array $context = [])
+    public function normalize(NormalizerInterface $normalizer, $format = null, array $context = [])
     {
         if ($this->highlight) {
             return $this->highlight->toArray();

--- a/src/SearchEndpoint/InnerHitsEndpoint.php
+++ b/src/SearchEndpoint/InnerHitsEndpoint.php
@@ -27,7 +27,7 @@ class InnerHitsEndpoint extends AbstractSearchEndpoint
     /**
      * {@inheritdoc}
      */
-    public function normalize(NormalizerInterface $normalizer, string $format = null, array $context = [])
+    public function normalize(NormalizerInterface $normalizer, $format = null, array $context = [])
     {
         $output = [];
         if (count($this->getAll()) > 0) {

--- a/src/SearchEndpoint/PostFilterEndpoint.php
+++ b/src/SearchEndpoint/PostFilterEndpoint.php
@@ -26,7 +26,7 @@ class PostFilterEndpoint extends QueryEndpoint
     /**
      * {@inheritdoc}
      */
-    public function normalize(NormalizerInterface $normalizer, string $format = null, array $context = [])
+    public function normalize(NormalizerInterface $normalizer, $format = null, array $context = [])
     {
         if (!$this->getBool()) {
             return null;

--- a/src/SearchEndpoint/QueryEndpoint.php
+++ b/src/SearchEndpoint/QueryEndpoint.php
@@ -39,7 +39,7 @@ class QueryEndpoint extends AbstractSearchEndpoint implements OrderedNormalizerI
     /**
      * {@inheritdoc}
      */
-    public function normalize(NormalizerInterface $normalizer, string $format = null, array $context = [])
+    public function normalize(NormalizerInterface $normalizer, $format = null, array $context = [])
     {
         if (!$this->filtersSet && $this->hasReference('filter_query')) {
             /** @var BuilderInterface $filter */

--- a/src/SearchEndpoint/SortEndpoint.php
+++ b/src/SearchEndpoint/SortEndpoint.php
@@ -26,7 +26,7 @@ class SortEndpoint extends AbstractSearchEndpoint
     /**
      * {@inheritdoc}
      */
-    public function normalize(NormalizerInterface $normalizer, string $format = null, array $context = [])
+    public function normalize(NormalizerInterface $normalizer, $format = null, array $context = [])
     {
         $output = [];
 

--- a/src/SearchEndpoint/SuggestEndpoint.php
+++ b/src/SearchEndpoint/SuggestEndpoint.php
@@ -27,7 +27,7 @@ class SuggestEndpoint extends AbstractSearchEndpoint
     /**
      * {@inheritdoc}
      */
-    public function normalize(NormalizerInterface $normalizer, string $format = null, array $context = [])
+    public function normalize(NormalizerInterface $normalizer, $format = null, array $context = [])
     {
         $output = [];
         if (count($this->getAll()) > 0) {

--- a/src/Serializer/Normalizer/CustomReferencedNormalizer.php
+++ b/src/Serializer/Normalizer/CustomReferencedNormalizer.php
@@ -26,7 +26,7 @@ class CustomReferencedNormalizer extends CustomNormalizer
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, string $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = [])
     {
         $object->setReferences($this->references);
         $data = parent::normalize($object, $format, $context);
@@ -38,7 +38,7 @@ class CustomReferencedNormalizer extends CustomNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization($data, $format = null)
     {
         return $data instanceof AbstractNormalizable;
     }


### PR DESCRIPTION
Currently we have different branches 6.0, 6.1, 6.2 which support different Elasticssearch Versions.  
As this would be higher maintenance work I added bc compatibility so 6.x will support all supported Symfony Versions used by us in the SuluArticleBundle.