### PR TITLE
Return integer values in uasort callback

### DIFF
--- a/src/Serializer/OrderedSerializer.php
+++ b/src/Serializer/OrderedSerializer.php
@@ -59,7 +59,7 @@ class OrderedSerializer extends Serializer
             uasort(
                 $filteredData,
                 function (OrderedNormalizerInterface $a, OrderedNormalizerInterface $b) {
-                    return $a->getOrder() > $b->getOrder();
+                    return $a->getOrder() > $b->getOrder() ? 1 : -1;
                 }
             );
 


### PR DESCRIPTION
Fixes PHP8 deprecation: `Deprecated: uasort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero`