### PR TITLE
Remove polyfill for random_bytes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     "require": {
         "php": "^7.1|^8.0",
         "symfony/serializer": "^2.8 || ^3.4 || ^4.0 || ^5.0",
-        "paragonie/random_compat": "^1 | ^2 | 9.99.99",
         "elasticsearch/elasticsearch": "^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
 [`random_bytes`polyfill](https://github.com/paragonie/random_compat) is only needed when supporting php 5. As the package with version 6 and 7 does require php 7 this requirement is not longer needed and so can be removed.