### PR TITLE
Add `minimum_should_match` parameter to `TermsSetQuery`

### DIFF
--- a/src/Query/TermLevel/TermsSetQuery.php
+++ b/src/Query/TermLevel/TermsSetQuery.php
@@ -23,6 +23,7 @@ class TermsSetQuery implements BuilderInterface
 {
     use ParametersTrait;
 
+    const MINIMUM_SHOULD_MATCH_TYPE = 'minimum_should_match';
     const MINIMUM_SHOULD_MATCH_TYPE_FIELD = 'minimum_should_match_field';
     const MINIMUM_SHOULD_MATCH_TYPE_SCRIPT = 'minimum_should_match_script';
 
@@ -76,9 +77,10 @@ class TermsSetQuery implements BuilderInterface
     private function validateParameters(array $parameters)
     {
         if (!isset($parameters[self::MINIMUM_SHOULD_MATCH_TYPE_FIELD]) &&
-            !isset($parameters[self::MINIMUM_SHOULD_MATCH_TYPE_SCRIPT])
+            !isset($parameters[self::MINIMUM_SHOULD_MATCH_TYPE_SCRIPT]) &&
+            !isset($parameters[self::MINIMUM_SHOULD_MATCH_TYPE])
         ) {
-            $message = "Either minimum_should_match_field or minimum_should_match_script must be set.";
+            $message = "Either minimum_should_match, minimum_should_match_field or minimum_should_match_script must be set.";
             throw new \InvalidArgumentException($message);
         }
     }


### PR DESCRIPTION
This PR adds support for the `minimum_should_match` parameter for a terms set query.

## References
https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-set-query.html#terms-set-field-params